### PR TITLE
feat: expand search, settings redesign, project templates (v0.2)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -43,7 +43,7 @@ xcodebuild \
 description = "Backup SwiftData store to ~/Desktop/EngagementTracker-backups/"
 run = """
 BACKUP_DIR="$HOME/Desktop/EngagementTracker-backups"
-DB_DIR="$HOME/Library/Application Support/com.greyhoundforty.EngagementTracker"
+DB_DIR="$HOME/Library/Containers/com.greyhoundforty.EngagementTracker/Data/Library/Application Support"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 DEST="$BACKUP_DIR/$TIMESTAMP"
 

--- a/EngagementTracker.xcodeproj/project.pbxproj
+++ b/EngagementTracker.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		681639735E96C7F2903DD59A /* Engagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE2A432222F09AE7920E6C9 /* Engagement.swift */; };
 		6FDCFFF80A71F9B9574BCA85 /* CheckpointSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E3A31D91687A72137F19BD /* CheckpointSeeder.swift */; };
 		70FA610E2294BA4A486D11C3 /* ProjectTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C50165EBA0FB0AF8AB4E47 /* ProjectTask.swift */; };
+		AA3B7C2D1E4F5A6B7C8D9E0F /* ProjectTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3B7C2D1E4F5A6B7C8D9E0F /* ProjectTemplate.swift */; };
 		7B52BB4E76FFAFE1D8F557F1 /* SearchFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD6CCD5883650AF903F00EF /* SearchFilterTests.swift */; };
 		7C0B9F30AF2EF01185B90166 /* ExportModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF34B930FBCC51AB1BC2125A /* ExportModelsTests.swift */; };
 		7C54EDA56C2F64CBD6CA3DC0 /* ProjectListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12EBC0A82C1D517978A4CD02 /* ProjectListView.swift */; };
@@ -76,6 +77,7 @@
 		627193FC2257799E20E92E14 /* Checkpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Checkpoint.swift; sourceTree = "<group>"; };
 		62B4AF03BAA576689329F6A0 /* Note.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Note.swift; sourceTree = "<group>"; };
 		63C50165EBA0FB0AF8AB4E47 /* ProjectTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTask.swift; sourceTree = "<group>"; };
+		BB3B7C2D1E4F5A6B7C8D9E0F /* ProjectTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTemplate.swift; sourceTree = "<group>"; };
 		6566B913CAC1CB94744A4B45 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		65FCCB00F67B9C0976DD24B9 /* ImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportService.swift; sourceTree = "<group>"; };
 		667315A690EA2A742742EC15 /* ProjectDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectDetailView.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 				62B4AF03BAA576689329F6A0 /* Note.swift */,
 				A9E731AD64C56074C9977ADD /* Project.swift */,
 				63C50165EBA0FB0AF8AB4E47 /* ProjectTask.swift */,
+				BB3B7C2D1E4F5A6B7C8D9E0F /* ProjectTemplate.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -403,6 +406,7 @@
 				E19D3443C1B7DEC0D92F8DE6 /* ProjectDetailView.swift in Sources */,
 				7C54EDA56C2F64CBD6CA3DC0 /* ProjectListView.swift in Sources */,
 				70FA610E2294BA4A486D11C3 /* ProjectTask.swift in Sources */,
+				AA3B7C2D1E4F5A6B7C8D9E0F /* ProjectTemplate.swift in Sources */,
 				4CBB53D9293C22A9F36C183B /* SettingsView.swift in Sources */,
 				FC9CFD95ECF54205F54B8CF8 /* StagesSidebarView.swift in Sources */,
 				49FB6145297DE1323DA76A9C /* TasksTabView.swift in Sources */,

--- a/EngagementTracker/App/AppState.swift
+++ b/EngagementTracker/App/AppState.swift
@@ -18,6 +18,10 @@ final class AppState {
     var themeMode: ThemeMode = ThemeMode(rawValue: UserDefaults.standard.string(forKey: "themeMode") ?? "system") ?? .system {
         didSet { UserDefaults.standard.set(themeMode.rawValue, forKey: "themeMode") }
     }
+    var templateFolderPath: String? {
+        get { UserDefaults.standard.string(forKey: "templateFolderPath") }
+        set { UserDefaults.standard.set(newValue, forKey: "templateFolderPath") }
+    }
 
     static func makeContainer(cloudSync: Bool) -> ModelContainer {
         let schema = Schema([

--- a/EngagementTracker/EngagementTracker.entitlements
+++ b/EngagementTracker/EngagementTracker.entitlements
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+</dict>
 </plist>

--- a/EngagementTracker/Info.plist
+++ b/EngagementTracker/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0</string>
+    <string>0.2</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSPrincipalClass</key>

--- a/EngagementTracker/Models/Project.swift
+++ b/EngagementTracker/Models/Project.swift
@@ -12,9 +12,9 @@ final class Project {
     var estimatedValueCents: Int?           // stored as cents to avoid Decimal SwiftData issues
     var targetCloseDate: Date?
     var tags: [String]
-    var iscOpportunityLink: String
-    var gtmNavAccountLink: String
-    var oneDriveFolderLink: String
+    var iscOpportunityLink: String?
+    var gtmNavAccountLink: String?
+    var oneDriveFolderLink: String?
     var isActive: Bool
     var createdAt: Date
     var updatedAt: Date
@@ -34,9 +34,9 @@ final class Project {
         estimatedValueCents: Int? = nil,
         targetCloseDate: Date? = nil,
         tags: [String] = [],
-        iscOpportunityLink: String = "",
-        gtmNavAccountLink: String = "",
-        oneDriveFolderLink: String = ""
+        iscOpportunityLink: String? = nil,
+        gtmNavAccountLink: String? = nil,
+        oneDriveFolderLink: String? = nil
     ) {
         self.id = UUID()
         self.name = name

--- a/EngagementTracker/Models/ProjectTemplate.swift
+++ b/EngagementTracker/Models/ProjectTemplate.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct ProjectTemplate: Codable, Identifiable, Hashable {
+    var id: String { name }
+    let name: String
+    let isPOC: Bool
+    let tags: [String]
+    let stage: String
+    let taskTitles: [String]
+
+    var projectStage: ProjectStage {
+        ProjectStage(rawValue: stage) ?? .discovery
+    }
+
+    static func load(from folderPath: String) -> [ProjectTemplate] {
+        let url = URL(fileURLWithPath: folderPath)
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: url, includingPropertiesForKeys: nil
+        ) else { return [] }
+        return contents
+            .filter { $0.pathExtension == "json" }
+            .compactMap { fileURL in
+                guard let data = try? Data(contentsOf: fileURL) else { return nil }
+                return try? JSONDecoder().decode(ProjectTemplate.self, from: data)
+            }
+            .sorted { $0.name < $1.name }
+    }
+}

--- a/EngagementTracker/Services/ExportService.swift
+++ b/EngagementTracker/Services/ExportService.swift
@@ -17,9 +17,9 @@ enum ExportService {
             estimatedValueCents: model.estimatedValueCents,
             targetCloseDate: model.targetCloseDate,
             tags: model.tags,
-            iscOpportunityLink: model.iscOpportunityLink,
-            gtmNavAccountLink: model.gtmNavAccountLink,
-            oneDriveFolderLink: model.oneDriveFolderLink,
+            iscOpportunityLink: model.iscOpportunityLink ?? "",
+            gtmNavAccountLink: model.gtmNavAccountLink ?? "",
+            oneDriveFolderLink: model.oneDriveFolderLink ?? "",
             contacts: model.contacts.map { contact(from: $0) },
             tasks: model.tasks.sorted { $0.createdAt < $1.createdAt }.map { task(from: $0) },
             notes: model.notes.sorted { $0.createdAt < $1.createdAt }.map { note(from: $0) },
@@ -80,7 +80,7 @@ enum ExportService {
                 p.estimatedValueCents.map { String($0) } ?? "",
                 p.targetCloseDate.map { iso8601($0) } ?? "",
                 p.tags.joined(separator: ";"),
-                p.iscOpportunityLink, p.gtmNavAccountLink, p.oneDriveFolderLink
+                p.iscOpportunityLink ?? "", p.gtmNavAccountLink ?? "", p.oneDriveFolderLink ?? ""
             ]
             projRows.append(row.map(csvEscape).joined(separator: ","))
         }

--- a/EngagementTracker/Views/Export/ImportSheet.swift
+++ b/EngagementTracker/Views/Export/ImportSheet.swift
@@ -173,6 +173,7 @@ struct ImportSheet: View {
             )
             context.insert(project)
 
+            var nameToContactID: [String: UUID] = [:]
             for c in exported.contacts {
                 let contact = Contact(
                     name: c.name, title: c.title, email: c.email,
@@ -181,6 +182,17 @@ struct ImportSheet: View {
                 )
                 context.insert(contact)
                 project.contacts.append(contact)
+                nameToContactID[c.name] = contact.id
+            }
+
+            for e in exported.engagements {
+                let engagement = Engagement(
+                    date: e.date,
+                    summary: e.summary,
+                    contactIDs: e.contactNames.compactMap { nameToContactID[$0] }
+                )
+                context.insert(engagement)
+                project.engagements.append(engagement)
             }
 
             for t in exported.tasks {

--- a/EngagementTracker/Views/Main/ProjectListView.swift
+++ b/EngagementTracker/Views/Main/ProjectListView.swift
@@ -23,7 +23,10 @@ struct ProjectListView: View {
         return byFilter.filter {
             $0.name.lowercased().contains(q) ||
             ($0.accountName?.lowercased().contains(q) ?? false) ||
-            ($0.opportunityID?.lowercased().contains(q) ?? false)
+            ($0.opportunityID?.lowercased().contains(q) ?? false) ||
+            $0.tags.contains { $0.lowercased().contains(q) } ||
+            $0.notes.contains { $0.content.lowercased().contains(q) } ||
+            $0.stage.rawValue.lowercased().contains(q)
         }
     }
 

--- a/EngagementTracker/Views/MenuBar/MenuBarPopoverView.swift
+++ b/EngagementTracker/Views/MenuBar/MenuBarPopoverView.swift
@@ -16,7 +16,9 @@ struct MenuBarPopoverView: View {
         let q = appState.searchQuery.lowercased()
         return activeProjects.filter {
             $0.name.lowercased().contains(q) ||
-            ($0.accountName?.lowercased().contains(q) ?? false)
+            ($0.accountName?.lowercased().contains(q) ?? false) ||
+            $0.tags.contains { $0.lowercased().contains(q) } ||
+            $0.stage.rawValue.lowercased().contains(q)
         }
     }
 

--- a/EngagementTracker/Views/Settings/SettingsView.swift
+++ b/EngagementTracker/Views/Settings/SettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct SettingsView: View {
     @Environment(AppState.self) private var appState
@@ -7,15 +8,9 @@ struct SettingsView: View {
         @Bindable var appState = appState
         Form {
             Section {
-                Toggle("Sync with iCloud", isOn: Binding(
-                    get: { appState.isCloudSyncEnabled },
-                    set: { appState.isCloudSyncEnabled = $0 }
-                ))
-                Text("Enables CloudKit sync across your Macs. Restart the app after changing this setting for it to take effect. Foundation for a future iOS companion app.")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
+                LabeledContent("Version", value: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.2")
             } header: {
-                Text("Sync")
+                Text("About")
             }
 
             Section {
@@ -33,12 +28,59 @@ struct SettingsView: View {
             }
 
             Section {
-                LabeledContent("Version", value: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
+                HStack {
+                    if let path = appState.templateFolderPath {
+                        Text(path)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Button("Clear") {
+                            appState.templateFolderPath = nil
+                        }
+                        .buttonStyle(.borderless)
+                    } else {
+                        Text("No folder selected")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    Button("Choose…") {
+                        chooseTemplateFolder()
+                    }
+                }
+                Text("JSON template files in this folder appear as options when creating a new project.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
             } header: {
-                Text("About")
+                Text("Templates")
+            }
+
+            Section {
+                Toggle("Sync with iCloud", isOn: Binding(
+                    get: { appState.isCloudSyncEnabled },
+                    set: { appState.isCloudSyncEnabled = $0 }
+                ))
+                Text("Enables CloudKit sync across your Macs. Restart the app after changing this setting for it to take effect.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            } header: {
+                Text("Sync")
             }
         }
         .formStyle(.grouped)
-        .frame(width: 420, height: 280)
+        .frame(width: 420, height: 380)
+    }
+
+    private func chooseTemplateFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Select Folder"
+        if panel.runModal() == .OK, let url = panel.url {
+            appState.templateFolderPath = url.path
+        }
     }
 }

--- a/EngagementTracker/Views/Sheets/NewProjectSheet.swift
+++ b/EngagementTracker/Views/Sheets/NewProjectSheet.swift
@@ -15,6 +15,12 @@ struct NewProjectSheet: View {
     @State private var hasCloseDate: Bool = false
     @State private var tagsString: String = ""
     @State private var initialStage: ProjectStage = .discovery
+    @State private var selectedTemplate: ProjectTemplate? = nil
+
+    private var availableTemplates: [ProjectTemplate] {
+        guard let path = appState.templateFolderPath else { return [] }
+        return ProjectTemplate.load(from: path)
+    }
 
     var isValid: Bool { !name.trimmingCharacters(in: .whitespaces).isEmpty }
 
@@ -41,6 +47,23 @@ struct NewProjectSheet: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
+                    if !availableTemplates.isEmpty {
+                        FormSection(title: "Template") {
+                            Picker("Apply Template", selection: $selectedTemplate) {
+                                Text("None").tag(Optional<ProjectTemplate>.none)
+                                ForEach(availableTemplates) { template in
+                                    Text(template.name).tag(Optional(template))
+                                }
+                            }
+                            .onChange(of: selectedTemplate) { _, template in
+                                guard let t = template else { return }
+                                isPOC = t.isPOC
+                                tagsString = t.tags.joined(separator: ", ")
+                                initialStage = t.projectStage
+                            }
+                        }
+                    }
+
                     FormSection(title: "Project") {
                         LabeledField(label: "Name *") {
                             TextField("Required", text: $name)
@@ -104,6 +127,13 @@ struct NewProjectSheet: View {
         checkpoints.forEach { cp in
             project.checkpoints.append(cp)
             context.insert(cp)
+        }
+        if let template = selectedTemplate {
+            template.taskTitles.forEach { title in
+                let task = ProjectTask(title: title)
+                project.tasks.append(task)
+                context.insert(task)
+            }
         }
         try? context.save()
         appState.selectedStage = project.stage

--- a/EngagementTracker/Views/Tabs/OverviewTabView.swift
+++ b/EngagementTracker/Views/Tabs/OverviewTabView.swift
@@ -72,21 +72,21 @@ struct OverviewTabView: View {
                     LinkRow(
                         label: "ISC Opportunity",
                         icon: "link.badge.plus",
-                        value: $project.iscOpportunityLink,
+                        value: linkBinding(\.iscOpportunityLink),
                         onSave: { try? context.save() }
                     )
                     Divider().padding(.vertical, 4)
                     LinkRow(
                         label: "GTM Nav Account",
                         icon: "building.2",
-                        value: $project.gtmNavAccountLink,
+                        value: linkBinding(\.gtmNavAccountLink),
                         onSave: { try? context.save() }
                     )
                     Divider().padding(.vertical, 4)
                     LinkRow(
                         label: "OneDrive Folder",
                         icon: "folder.badge.questionmark",
-                        value: $project.oneDriveFolderLink,
+                        value: linkBinding(\.oneDriveFolderLink),
                         onSave: { try? context.save() }
                     )
                 }
@@ -94,6 +94,13 @@ struct OverviewTabView: View {
             .padding()
         }
         .background(Color.gruvBg)
+    }
+
+    private func linkBinding(_ keyPath: ReferenceWritableKeyPath<Project, String?>) -> Binding<String> {
+        Binding(
+            get: { project[keyPath: keyPath] ?? "" },
+            set: { project[keyPath: keyPath] = $0.isEmpty ? nil : $0 }
+        )
     }
 
     private func initials(for name: String) -> String {

--- a/EngagementTrackerTests/SearchFilterTests.swift
+++ b/EngagementTrackerTests/SearchFilterTests.swift
@@ -42,4 +42,39 @@ struct SearchFilterTests {
         let project = Project(name: "Test", estimatedValueCents: nil)
         #expect(project.estimatedValueFormatted == nil)
     }
+
+    @Test func matchesOnTag() {
+        let project = Project(name: "Deal 001", tags: ["cloud", "security"])
+        let q = "cloud"
+        let matches = project.tags.contains { $0.lowercased().contains(q) }
+        #expect(matches == true)
+    }
+
+    @Test func matchesOnTagPartial() {
+        let project = Project(name: "Deal 001", tags: ["cloud-native", "security"])
+        let q = "native"
+        let matches = project.tags.contains { $0.lowercased().contains(q) }
+        #expect(matches == true)
+    }
+
+    @Test func noMatchOnAbsentTag() {
+        let project = Project(name: "Deal 001", tags: ["cloud", "security"])
+        let q = "networking"
+        let matches = project.tags.contains { $0.lowercased().contains(q) }
+        #expect(matches == false)
+    }
+
+    @Test func matchesOnStageRawValue() {
+        let project = makeProject(name: "Deal 001", stage: .proposal)
+        let q = "proposal"
+        let matches = project.stage.rawValue.lowercased().contains(q)
+        #expect(matches == true)
+    }
+
+    @Test func matchesOnStagePartial() {
+        let project = makeProject(name: "Deal 001", stage: .initialDelivery)
+        let q = "initial"
+        let matches = project.stage.rawValue.lowercased().contains(q)
+        #expect(matches == true)
+    }
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A macOS app for tracking IBM sales engagements as projects. Runs as both a menu bar popover (quick access) and a full dock window (project management). Local-first storage via SwiftData with optional iCloud sync.
 
-Projects move through a fixed lifecycle: Discovery -> Initial Delivery -> Refine -> Proposal -> Won/Lost. Each project tracks contacts (customer, IBM, business partner), stage checkpoints, tasks, timestamped engagement logs, and notes.
+Projects move through a fixed lifecycle: Discovery → Initial Delivery → Refine → Proposal → Won/Lost. Each project tracks contacts (customer, IBM, business partner), stage checkpoints, tasks, timestamped engagement logs, and notes.
 
 ## Requirements
 
@@ -11,7 +11,9 @@ Projects move through a fixed lifecycle: Discovery -> Initial Delivery -> Refine
 - [xcodegen](https://github.com/yonaskolb/XcodeGen) — `brew install xcodegen`
 - [mise](https://mise.jdx.dev) (optional, for terminal build tasks) — `brew install mise`
 
-## Build
+## Build and Run
+
+### Xcode (recommended)
 
 ```bash
 git clone https://github.com/greyhoundforty/engagement-tracker.git
@@ -22,14 +24,51 @@ open EngagementTracker.xcodeproj
 
 Press `Cmd+R` to build and run.
 
-## Terminal builds (mise)
+### Terminal — with mise
 
 ```bash
 mise run build        # Debug build
+mise run test         # Run unit tests
 mise run clean        # Clean build products
 mise run clean-build  # Clean then build
-mise run test         # Run unit tests
+mise run db-backup    # Backup SwiftData store to ~/Desktop/EngagementTracker-backups/
 ```
+
+To build and launch in one step:
+
+```bash
+mise run build && open ~/Library/Developer/Xcode/DerivedData/EngagementTracker-*/Build/Products/Debug/EngagementTracker.app
+```
+
+### Terminal — without mise (xcodebuild directly)
+
+```bash
+# Debug build
+xcodebuild \
+  -project EngagementTracker.xcodeproj \
+  -scheme EngagementTracker \
+  -destination 'platform=macOS,arch=arm64' \
+  -configuration Debug \
+  build
+
+# Run unit tests
+xcodebuild \
+  -project EngagementTracker.xcodeproj \
+  -scheme EngagementTrackerTests \
+  -destination 'platform=macOS,arch=arm64' \
+  test
+
+# Build and launch
+xcodebuild \
+  -project EngagementTracker.xcodeproj \
+  -scheme EngagementTracker \
+  -destination 'platform=macOS,arch=arm64' \
+  -configuration Debug \
+  build && \
+open ~/Library/Developer/Xcode/DerivedData/EngagementTracker-*/Build/Products/Debug/EngagementTracker.app
+```
+
+> **Note:** Builds from the terminal use ad-hoc codesigning. The app sandbox entitlement ensures they share the same SwiftData store as Xcode-run builds (`~/Library/Containers/com.greyhoundforty.EngagementTracker/`).
 
 ## Project structure
 
@@ -37,14 +76,14 @@ mise run test         # Run unit tests
 project.yml                  # xcodegen project spec — source of truth for the Xcode project
 EngagementTracker/
   App/                       # App entry point, AppState, ModelContainer setup
-  Models/                    # SwiftData models and enums
-  Services/                  # Export and import logic (Phase 2)
+  Models/                    # SwiftData models, enums, and ProjectTemplate
+  Services/                  # Export and import logic
   Theme/                     # Gruvbox color extensions and asset catalog
   Views/
     Main/                    # NavigationSplitView, sidebar, project list, detail
     Tabs/                    # Per-tab views (Overview, Checkpoints, Tasks, etc.)
     Sheets/                  # New project, add contact, log engagement sheets
-    Export/                  # Export and import sheets (Phase 2)
+    Export/                  # Export and import sheets
     MenuBar/                 # Menu bar popover
     Settings/                # Settings window
 EngagementTrackerTests/      # Swift Testing unit tests
@@ -61,9 +100,39 @@ The `.xcodeproj` is generated from `project.yml` by xcodegen. After adding or re
 xcodegen generate
 ```
 
+> **Note:** If you add files manually without xcodegen (e.g. during a worktree session), add the file references directly to `project.pbxproj` — see any existing model file as a template for the three required entries (PBXBuildFile, PBXFileReference, PBXGroup, PBXSourcesBuildPhase).
+
+## Importing test data
+
+A test project file is included at `docs/test-projects.json`. Import it via the **↓ toolbar button** in the project list to populate the app with sample data across all pipeline stages.
+
+The import sheet accepts:
+- **JSON** — full `ExportBundle` with projects, contacts, engagements, notes, tasks, and checkpoints
+- **CSV** — `projects.csv` from a zip export (project metadata only; child records not included)
+
+## Project templates
+
+To use templates when creating new projects:
+
+1. Open **Settings → Templates** and choose a folder containing `.json` template files.
+2. Each template file defines default values for a new project:
+
+```json
+{
+  "name": "POC Engagement",
+  "isPOC": true,
+  "tags": ["poc"],
+  "stage": "Discovery",
+  "taskTitles": ["Define POC scope", "Environment setup", "Build POC", "Present results"]
+}
+```
+
+3. When creating a new project the template picker appears at the top of the sheet. Selecting a template pre-fills stage, tags, isPOC, and creates initial tasks on save.
+
 ## Notes
 
 - Swift is pinned to 5.9 in `project.yml` to avoid Swift 6 concurrency strictness with SwiftData. Do not bump without testing.
 - The `ModelContainer` is a `@State` property on the app struct — one instance shared across all scenes. Do not make it a computed property.
 - Changing the iCloud sync setting in Settings requires an app restart.
+- The three link fields (`iscOpportunityLink`, `gtmNavAccountLink`, `oneDriveFolderLink`) are `String?` — existing records with NULL values migrate cleanly. Do not change them back to non-optional without a versioned migration plan.
 - See `docs/PHASE1_SESSION.md` for SwiftData migration rules before changing any model properties.


### PR DESCRIPTION
## Summary

- **Search expanded** (closes #2) — project list and menu bar popover now match on tags, notes content, and stage in addition to name/account/opportunity ID; 5 new unit tests added
- **Settings redesigned** — version at top, Sync moved to bottom, new Templates section with folder picker
- **Project templates** — configure a folder of JSON templates; New Project sheet pre-fills stage, tags, isPOC, and seeds initial tasks from the selected template
- **Import fix** — engagements were silently dropped on import; now imported with contact linkage resolved by name
- **SwiftData/sandbox fixes** — app-sandbox entitlement added so terminal and Xcode builds share the same container; three optional link fields (`iscOpportunityLink`, `gtmNavAccountLink`, `oneDriveFolderLink`) changed from `String` to `String?` to allow lightweight migration of existing rows without data loss

## Test plan

- [ ] Build via Xcode (`Cmd+R`) and via terminal (`mise run build` or `xcodebuild` directly) — both should launch and show existing data
- [ ] `mise run test` — all 32 tests pass
- [ ] Search: type a tag name, a stage name, and a word from a note — matching projects appear
- [ ] Settings: version shows 0.2 at top; theme picker works; template folder picker opens and saves path; Sync toggle at bottom
- [ ] Templates: point template folder at a directory with a `.json` template file, open New Project — template picker appears and pre-fills fields
- [ ] Import: use the ↓ toolbar button and import `docs/test-projects.json` — 4 test projects created across Discovery/Initial Delivery/Refine/Proposal stages with contacts, engagements, notes, and tasks
- [ ] Export then re-import the same file — engagements survive the round-trip

## Notes for reviewers

The three link fields are now `String?`. Any existing database with non-null values is unaffected. The migration only matters for records that were created before those columns existed (NULL rows) — previously this caused a fatal crash on launch.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)