### PR TITLE
feat: tag/label system, inline tag editor, and engagement calendar

### DIFF
--- a/EngagementTracker/App/AppState.swift
+++ b/EngagementTracker/App/AppState.swift
@@ -9,6 +9,7 @@ enum ThemeMode: String {
 final class AppState {
     var selectedStage: ProjectStage? = .discovery
     var selectedTag: String? = nil
+    var selectedLabel: String? = nil
     var selectedProject: Project?
     var searchQuery: String = ""
     var isCloudSyncEnabled: Bool {

--- a/EngagementTracker/Views/Main/ProjectDetailView.swift
+++ b/EngagementTracker/Views/Main/ProjectDetailView.swift
@@ -41,6 +41,7 @@ struct ProjectDetailHeaderView: View {
     @State private var showStagePicker = false
     @State private var showDeleteConfirm = false
     @State private var showExport = false
+    @State private var showTagEditor = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -109,10 +110,31 @@ struct ProjectDetailHeaderView: View {
                     TagPill(label: value, color: .themeGreen)
                 }
                 if let account = project.accountName {
-                    TagPill(label: account, color: .themeFgDim)
+                    TagPill(label: account.replacingOccurrences(of: " ", with: "-"), color: .themeBlue)
                 }
                 if let closeDate = project.targetCloseDate {
                     TagPill(label: "Close: \(closeDate.formatted(date: .abbreviated, time: .omitted))", color: .themeFgDim)
+                }
+                let projectTags = project.tags.filter { $0.hasPrefix("#") }
+                if !projectTags.isEmpty {
+                    Text("|")
+                        .font(.system(size: 11))
+                        .foregroundStyle(Color.themeFgDim)
+                    ForEach(projectTags, id: \.self) { tag in
+                        TagPill(label: String(tag.dropFirst()), color: .themeYellow)
+                    }
+                }
+                Button {
+                    showTagEditor = true
+                } label: {
+                    Image(systemName: "tag")
+                        .font(.system(size: 11))
+                        .foregroundStyle(Color.themeFgDim)
+                }
+                .buttonStyle(.plain)
+                .help("Edit tags")
+                .popover(isPresented: $showTagEditor, arrowEdge: .bottom) {
+                    TagsEditorPopover(project: project)
                 }
             }
         }
@@ -195,5 +217,84 @@ struct TagPill: View {
             .padding(.vertical, 3)
             .background(Color.themeBg2)
             .clipShape(Capsule())
+    }
+}
+
+struct TagsEditorPopover: View {
+    let project: Project
+    @Environment(\.modelContext) private var context
+    @State private var newTag: String = ""
+
+    private var tags: [String] { project.tags.filter { $0.hasPrefix("#") } }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Edit Tags")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color.themeFgDim)
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
+
+            Divider()
+
+            if tags.isEmpty {
+                Text("No tags yet")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color.themeFgDim)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 4)
+            } else {
+                ForEach(tags, id: \.self) { tag in
+                    HStack {
+                        Text(String(tag.dropFirst()))
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color.themeYellow)
+                        Spacer()
+                        Button {
+                            removeTag(tag)
+                        } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 10))
+                                .foregroundStyle(Color.themeFgDim)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 5)
+                }
+            }
+
+            Divider()
+
+            HStack(spacing: 6) {
+                TextField("Add tag", text: $newTag)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12))
+                    .onSubmit { addTag() }
+                Button("Add") { addTag() }
+                    .disabled(newTag.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+        }
+        .frame(width: 200)
+        .background(Color.themeBg1)
+    }
+
+    private func addTag() {
+        let raw = newTag.trimmingCharacters(in: .whitespaces).trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        guard !raw.isEmpty else { return }
+        let tag = "#\(raw)"
+        guard !project.tags.contains(tag) else { newTag = ""; return }
+        project.tags.append(tag)
+        project.updatedAt = Date()
+        try? context.save()
+        newTag = ""
+    }
+
+    private func removeTag(_ tag: String) {
+        project.tags.removeAll { $0 == tag }
+        project.updatedAt = Date()
+        try? context.save()
     }
 }

--- a/EngagementTracker/Views/Main/ProjectListView.swift
+++ b/EngagementTracker/Views/Main/ProjectListView.swift
@@ -11,7 +11,9 @@ struct ProjectListView: View {
     private var filtered: [Project] {
         let base = allProjects.filter(\.isActive)
         let byFilter: [Project]
-        if let tag = appState.selectedTag {
+        if let label = appState.selectedLabel {
+            byFilter = base.filter { $0.accountName == label }
+        } else if let tag = appState.selectedTag {
             byFilter = base.filter { $0.tags.contains(tag) }
         } else if let stage = appState.selectedStage {
             byFilter = base.filter { $0.stage == stage }
@@ -48,7 +50,12 @@ struct ProjectListView: View {
         }
         .listStyle(.inset)
         .frame(minWidth: 220)
-        .navigationTitle(appState.selectedTag.map { "#\($0)" } ?? appState.selectedStage?.rawValue ?? "All Projects")
+        .navigationTitle(
+            appState.selectedLabel.map { $0.replacingOccurrences(of: " ", with: "-") }
+            ?? appState.selectedTag.map { String($0.dropFirst()) }
+            ?? appState.selectedStage?.rawValue
+            ?? "All Projects"
+        )
         .overlay {
             if filtered.isEmpty {
                 ContentUnavailableView(

--- a/EngagementTracker/Views/Main/StagesSidebarView.swift
+++ b/EngagementTracker/Views/Main/StagesSidebarView.swift
@@ -5,10 +5,14 @@ struct StagesSidebarView: View {
     @Environment(AppState.self) private var appState
     @Query private var projects: [Project]
 
+    private var allLabels: [String] {
+        let active = projects.filter(\.isActive)
+        return Set(active.compactMap(\.accountName).filter { !$0.isEmpty }).sorted()
+    }
+
     private var allTags: [String] {
         let active = projects.filter(\.isActive)
-        let tagSet = Set(active.flatMap(\.tags))
-        return tagSet.sorted()
+        return Set(active.flatMap(\.tags).filter { $0.hasPrefix("#") }).sorted()
     }
 
     var body: some View {
@@ -18,11 +22,12 @@ struct StagesSidebarView: View {
                     label: "All Projects",
                     icon: "folder",
                     badge: projects.filter(\.isActive).count,
-                    isSelected: appState.selectedStage == nil && appState.selectedTag == nil,
+                    isSelected: appState.selectedStage == nil && appState.selectedTag == nil && appState.selectedLabel == nil,
                     color: .themeFg
                 ) {
                     appState.selectedStage = nil
                     appState.selectedTag = nil
+                    appState.selectedLabel = nil
                 }
             }
 
@@ -32,11 +37,12 @@ struct StagesSidebarView: View {
                         label: stage.rawValue,
                         icon: stageIcon(stage),
                         badge: count(for: stage),
-                        isSelected: appState.selectedStage == stage && appState.selectedTag == nil,
+                        isSelected: appState.selectedStage == stage && appState.selectedTag == nil && appState.selectedLabel == nil,
                         color: Color.themeStageColor(for: stage)
                     ) {
                         appState.selectedStage = stage
                         appState.selectedTag = nil
+                        appState.selectedLabel = nil
                     }
                 }
             }
@@ -46,21 +52,41 @@ struct StagesSidebarView: View {
                     label: ProjectStage.won.rawValue,
                     icon: "checkmark.seal.fill",
                     badge: count(for: .won),
-                    isSelected: appState.selectedStage == .won && appState.selectedTag == nil,
+                    isSelected: appState.selectedStage == .won && appState.selectedTag == nil && appState.selectedLabel == nil,
                     color: .themeGreen
                 ) {
                     appState.selectedStage = .won
                     appState.selectedTag = nil
+                    appState.selectedLabel = nil
                 }
                 SidebarRow(
                     label: ProjectStage.lost.rawValue,
                     icon: "xmark.seal.fill",
                     badge: count(for: .lost),
-                    isSelected: appState.selectedStage == .lost && appState.selectedTag == nil,
+                    isSelected: appState.selectedStage == .lost && appState.selectedTag == nil && appState.selectedLabel == nil,
                     color: .themeRed
                 ) {
                     appState.selectedStage = .lost
                     appState.selectedTag = nil
+                    appState.selectedLabel = nil
+                }
+            }
+
+            if !allLabels.isEmpty {
+                Section("Labels") {
+                    ForEach(allLabels, id: \.self) { label in
+                        SidebarRow(
+                            label: label.replacingOccurrences(of: " ", with: "-"),
+                            icon: "at",
+                            badge: labelCount(label),
+                            isSelected: appState.selectedLabel == label,
+                            color: .themeBlue
+                        ) {
+                            appState.selectedLabel = label
+                            appState.selectedTag = nil
+                            appState.selectedStage = nil
+                        }
+                    }
                 }
             }
 
@@ -68,13 +94,14 @@ struct StagesSidebarView: View {
                 Section("Tags") {
                     ForEach(allTags, id: \.self) { tag in
                         SidebarRow(
-                            label: tag,
-                            icon: "tag",
+                            label: String(tag.dropFirst()),
+                            icon: "number",
                             badge: tagCount(tag),
                             isSelected: appState.selectedTag == tag,
                             color: .themeYellow
                         ) {
                             appState.selectedTag = tag
+                            appState.selectedLabel = nil
                             appState.selectedStage = nil
                         }
                     }
@@ -88,6 +115,10 @@ struct StagesSidebarView: View {
 
     private func count(for stage: ProjectStage) -> Int {
         projects.filter { $0.stage == stage && $0.isActive }.count
+    }
+
+    private func labelCount(_ accountName: String) -> Int {
+        projects.filter { $0.isActive && $0.accountName == accountName }.count
     }
 
     private func tagCount(_ tag: String) -> Int {

--- a/EngagementTracker/Views/Sheets/NewProjectSheet.swift
+++ b/EngagementTracker/Views/Sheets/NewProjectSheet.swift
@@ -58,7 +58,7 @@ struct NewProjectSheet: View {
                             .onChange(of: selectedTemplate) { _, template in
                                 guard let t = template else { return }
                                 isPOC = t.isPOC
-                                tagsString = t.tags.joined(separator: ", ")
+                                tagsString = t.tags.filter { $0.hasPrefix("#") }.map { String($0.dropFirst()) }.joined(separator: ", ")
                                 initialStage = t.projectStage
                             }
                         }
@@ -94,8 +94,8 @@ struct NewProjectSheet: View {
                             DatePicker("Close Date", selection: $targetCloseDate, displayedComponents: .date)
                                 .foregroundStyle(Color.themeFg)
                         }
-                        LabeledField(label: "Tags (comma-separated)") {
-                            TextField("Optional", text: $tagsString)
+                        LabeledField(label: "Tags (resource types, comma-separated)") {
+                            TextField("e.g. vpc, iks, powervs", text: $tagsString)
                         }
                     }
 
@@ -120,7 +120,9 @@ struct NewProjectSheet: View {
             isPOC: isPOC,
             estimatedValueCents: parseCents(estimatedValueString),
             targetCloseDate: hasCloseDate ? targetCloseDate : nil,
-            tags: tagsString.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+            tags: tagsString.split(separator: ",")
+                .map { "#\($0.trimmingCharacters(in: .whitespaces).trimmingCharacters(in: CharacterSet(charactersIn: "#")))" }
+                .filter { $0 != "#" }
         )
         context.insert(project)
         let checkpoints = CheckpointSeeder.makeAllCheckpoints()

--- a/EngagementTracker/Views/Tabs/OverviewTabView.swift
+++ b/EngagementTracker/Views/Tabs/OverviewTabView.swift
@@ -7,14 +7,11 @@ struct OverviewTabView: View {
 
     var body: some View {
         @Bindable var project = project
-        let ibmTeam = project.contacts
-            .filter { $0.type == .ibmInternal }
-            .sorted { $0.name < $1.name }
 
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
 
-                // Project summary card
+                // Combined Project Info + Links card
                 OverviewCard(title: "Project Info") {
                     OverviewInfoRow(label: "Account", value: project.accountName ?? "—")
                     OverviewInfoRow(label: "Stage") {
@@ -25,71 +22,38 @@ struct OverviewTabView: View {
                     if let oppID = project.opportunityID, !oppID.isEmpty {
                         OverviewInfoRow(label: "Opp ID", value: oppID)
                     }
-                    if !project.tags.isEmpty {
-                        OverviewInfoRow(label: "Tags", value: project.tags.joined(separator: ", "))
+                    let projectTags = project.tags.filter { $0.hasPrefix("#") }
+                    if !projectTags.isEmpty {
+                        OverviewInfoRow(label: "Tags", value: projectTags.map { String($0.dropFirst()) }.joined(separator: ", "))
+                    }
+
+                    Divider().padding(.vertical, 6)
+
+                    HStack(spacing: 16) {
+                        LinkIconButton(
+                            label: "ISC Opportunity",
+                            icon: "link.badge.plus",
+                            value: linkBinding(\.iscOpportunityLink),
+                            onSave: { try? context.save() }
+                        )
+                        LinkIconButton(
+                            label: "GTM Nav Account",
+                            icon: "building.2",
+                            value: linkBinding(\.gtmNavAccountLink),
+                            onSave: { try? context.save() }
+                        )
+                        LinkIconButton(
+                            label: "OneDrive Folder",
+                            icon: "folder.badge.questionmark",
+                            value: linkBinding(\.oneDriveFolderLink),
+                            onSave: { try? context.save() }
+                        )
+                        Spacer()
                     }
                 }
 
-                // IBM team card (only shown when contacts exist)
-                if !ibmTeam.isEmpty {
-                    OverviewCard(title: "IBM Team") {
-                        ForEach(ibmTeam) { contact in
-                            HStack(spacing: 8) {
-                                Circle()
-                                    .fill(Color.themeBg3)
-                                    .frame(width: 28, height: 28)
-                                    .overlay(
-                                        Text(initials(for: contact.name))
-                                            .font(.system(size: 11, weight: .semibold))
-                                            .foregroundStyle(Color.themeFg)
-                                    )
-                                Text(contact.name)
-                                    .font(.system(size: 13))
-                                    .foregroundStyle(Color.themeFg)
-                                if let role = contact.internalRole {
-                                    Text(role.rawValue)
-                                        .font(.system(size: 10))
-                                        .foregroundStyle(Color.themeAqua)
-                                        .padding(.horizontal, 6)
-                                        .padding(.vertical, 1)
-                                        .background(Color.themeBg2)
-                                        .clipShape(Capsule())
-                                }
-                                Spacer()
-                                if let email = contact.email, !email.isEmpty {
-                                    Text(email)
-                                        .font(.system(size: 11))
-                                        .foregroundStyle(Color.themeBlue)
-                                }
-                            }
-                            .padding(.vertical, 2)
-                        }
-                    }
-                }
-
-                // Links card
-                OverviewCard(title: "Links") {
-                    LinkRow(
-                        label: "ISC Opportunity",
-                        icon: "link.badge.plus",
-                        value: linkBinding(\.iscOpportunityLink),
-                        onSave: { try? context.save() }
-                    )
-                    Divider().padding(.vertical, 4)
-                    LinkRow(
-                        label: "GTM Nav Account",
-                        icon: "building.2",
-                        value: linkBinding(\.gtmNavAccountLink),
-                        onSave: { try? context.save() }
-                    )
-                    Divider().padding(.vertical, 4)
-                    LinkRow(
-                        label: "OneDrive Folder",
-                        icon: "folder.badge.questionmark",
-                        value: linkBinding(\.oneDriveFolderLink),
-                        onSave: { try? context.save() }
-                    )
-                }
+                // Engagement calendar
+                EngagementCalendarView(engagements: project.engagements)
             }
             .padding()
         }
@@ -102,59 +66,203 @@ struct OverviewTabView: View {
             set: { project[keyPath: keyPath] = $0.isEmpty ? nil : $0 }
         )
     }
+}
 
-    private func initials(for name: String) -> String {
-        let parts = name.split(separator: " ")
-        let first = parts.first.map { String($0.prefix(1)) } ?? ""
-        let last = parts.count > 1 ? parts.last.map { String($0.prefix(1)) } ?? "" : ""
-        return (first + last).uppercased()
+// MARK: - Engagement Calendar
+
+struct EngagementCalendarView: View {
+    let engagements: [Engagement]
+
+    @State private var displayedMonth: Date = {
+        let cal = Calendar.current
+        let comps = cal.dateComponents([.year, .month], from: Date())
+        return cal.date(from: comps) ?? Date()
+    }()
+
+    private let calendar = Calendar.current
+    private let dayColumns = Array(repeating: GridItem(.flexible(), spacing: 4), count: 7)
+    private let weekdaySymbols = Calendar.current.veryShortWeekdaySymbols
+
+    private var engagementDays: Set<String> {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        return Set(engagements.map { fmt.string(from: $0.date) })
+    }
+
+    private var daysInGrid: [Date?] {
+        guard let monthStart = calendar.date(from: calendar.dateComponents([.year, .month], from: displayedMonth)),
+              let range = calendar.range(of: .day, in: .month, for: monthStart) else { return [] }
+        let firstWeekday = calendar.component(.weekday, from: monthStart)
+        let leadingBlanks = (firstWeekday - calendar.firstWeekday + 7) % 7
+        var days: [Date?] = Array(repeating: nil, count: leadingBlanks)
+        for day in range {
+            days.append(calendar.date(byAdding: .day, value: day - 1, to: monthStart))
+        }
+        return days
+    }
+
+    var body: some View {
+        OverviewCard(title: "Engagement Activity") {
+            // Month navigation header
+            HStack {
+                Button {
+                    displayedMonth = calendar.date(byAdding: .month, value: -1, to: displayedMonth) ?? displayedMonth
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Color.themeFgDim)
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
+
+                Text(displayedMonth, format: .dateTime.month(.wide).year())
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.themeFg)
+
+                Spacer()
+
+                Button {
+                    displayedMonth = calendar.date(byAdding: .month, value: 1, to: displayedMonth) ?? displayedMonth
+                } label: {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Color.themeFgDim)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.bottom, 4)
+
+            // Weekday headers
+            LazyVGrid(columns: dayColumns, spacing: 4) {
+                ForEach(weekdaySymbols, id: \.self) { symbol in
+                    Text(symbol)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(Color.themeFgDim)
+                        .frame(maxWidth: .infinity)
+                }
+
+                // Day cells
+                ForEach(Array(daysInGrid.enumerated()), id: \.offset) { _, date in
+                    if let date {
+                        CalendarDayCell(date: date, hasEngagement: engagementDays.contains(dayKey(date)), isToday: calendar.isDateInToday(date))
+                    } else {
+                        Color.clear.frame(height: 28)
+                    }
+                }
+            }
+
+            // Legend
+            if !engagementDays.isEmpty {
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(Color.themeAqua.opacity(0.35))
+                        .frame(width: 8, height: 8)
+                    Text("Engagement logged")
+                        .font(.system(size: 10))
+                        .foregroundStyle(Color.themeFgDim)
+                }
+                .padding(.top, 6)
+            }
+        }
+    }
+
+    private func dayKey(_ date: Date) -> String {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        return fmt.string(from: date)
     }
 }
 
-// MARK: - Link row with inline editing + open button
+private struct CalendarDayCell: View {
+    let date: Date
+    let hasEngagement: Bool
+    let isToday: Bool
 
-struct LinkRow: View {
+    var body: some View {
+        ZStack {
+            if hasEngagement {
+                Circle()
+                    .fill(Color.themeAqua.opacity(0.35))
+            } else if isToday {
+                Circle()
+                    .strokeBorder(Color.themeFgDim.opacity(0.4), lineWidth: 1)
+            }
+            Text("\(Calendar.current.component(.day, from: date))")
+                .font(.system(size: 11, weight: hasEngagement ? .semibold : .regular))
+                .foregroundStyle(hasEngagement ? Color.themeAqua : (isToday ? Color.themeFg : Color.themeFgDim))
+        }
+        .frame(height: 28)
+    }
+}
+
+// MARK: - Link icon button with popover editor
+
+struct LinkIconButton: View {
     let label: String
     let icon: String
     @Binding var value: String
     let onSave: () -> Void
 
+    @State private var showPopover = false
+
     private var url: URL? {
         let s = value.trimmingCharacters(in: .whitespaces)
         guard !s.isEmpty else { return nil }
-        // Prepend https:// if missing a scheme so URL(string:) parses it
         let normalized = s.hasPrefix("http") ? s : "https://\(s)"
         return URL(string: normalized)
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 6) {
+        Button {
+            if let url {
+                NSWorkspace.shared.open(url)
+            } else {
+                showPopover = true
+            }
+        } label: {
+            VStack(spacing: 4) {
                 Image(systemName: icon)
-                    .font(.system(size: 12))
+                    .font(.system(size: 16))
                     .foregroundStyle(url != nil ? Color.themeAqua : Color.themeBg3)
-                    .frame(width: 18)
+                Text(label)
+                    .font(.system(size: 9))
+                    .foregroundStyle(url != nil ? Color.themeAqua : Color.themeFgDim.opacity(0.5))
+                    .underline(url != nil)
+                    .lineLimit(1)
+            }
+        }
+        .buttonStyle(.plain)
+        .help(url != nil ? "Open \(label)" : "Set \(label)")
+        .contextMenu {
+            if url != nil {
+                Button("Edit Link") { showPopover = true }
+                Button("Clear Link") { value = ""; onSave() }
+            } else {
+                Button("Set Link") { showPopover = true }
+            }
+        }
+        .popover(isPresented: $showPopover, arrowEdge: .bottom) {
+            VStack(alignment: .leading, spacing: 8) {
                 Text(label)
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(Color.themeFgDim)
-                Spacer()
-                if let url {
-                    Link(destination: url) {
-                        HStack(spacing: 3) {
-                            Text("Open")
-                                .font(.system(size: 11))
-                            Image(systemName: "arrow.up.right.square")
-                                .font(.system(size: 11))
-                        }
-                        .foregroundStyle(Color.themeBlue)
+                HStack(spacing: 6) {
+                    TextField("Paste link…", text: $value)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 12))
+                        .frame(width: 260)
+                        .onSubmit { onSave(); showPopover = false }
+                    if url != nil {
+                        Button("Clear") { value = ""; onSave(); showPopover = false }
+                            .font(.system(size: 11))
                     }
+                    Button("Save") { onSave(); showPopover = false }
+                        .font(.system(size: 11))
                 }
             }
-            TextField("Paste link…", text: $value)
-                .textFieldStyle(.roundedBorder)
-                .font(.system(size: 12))
-                .foregroundStyle(Color.themeFg)
-                .onSubmit { onSave() }
+            .padding(12)
+            .background(Color.themeBg1)
         }
     }
 }


### PR DESCRIPTION
Closes #5

## Summary

- **Labels** derive from `accountName` (spaces → hyphens for display); a new "Labels" sidebar section filters projects by account name via `AppState.selectedLabel` — no `@` prefix stored, no schema migration needed
- **Tags** use `#` prefix (e.g. `#vpc`, `#iks`) stored in the existing `tags: [String]` field; sidebar "Tags" section and project header both show stripped display names
- **Inline tag editor** popover in the project header lets you add/remove `#tags` on existing projects
- **Overview tab redesign**: Project Info + Links combined into one card; links are now icon-only — greyed when unset, aqua + underlined when set, click to open or right-click to edit/clear; IBM Team section removed; monthly engagement activity calendar added with highlighted days for logged engagements

## Test plan

- [ ] Create a project with an Account Name and resource tags (e.g. `vpc, iks`) — verify sidebar shows account under Labels and tags under Tags
- [ ] Click a Label in sidebar — verify project list filters by account name and nav title shows hyphenated name
- [ ] Click a Tag in sidebar — verify project list filters correctly
- [ ] Open an existing project header → click the tag icon → add and remove tags
- [ ] Overview tab: verify Project Info and Links are in one card; link icons grey when unset, aqua when set; clicking a set link opens the URL; right-click shows Edit/Clear options
- [ ] Overview tab: verify engagement calendar highlights days with logged engagements; month navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)